### PR TITLE
Add support for embedded PolyGlot BIN books

### DIFF
--- a/src/polybook.h
+++ b/src/polybook.h
@@ -23,6 +23,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "position.h"
 #include "string.h"
 
+#if defined(POLY_EMBEDDING_ON)
+    #if defined(_MSC_VER)
+        #undef POLY_EMBEDDING_ON
+    #else
+        #include "incbin/incbin.h"
+    #endif
+#endif
+
 typedef struct {
     uint64_t key;
     uint16_t move;
@@ -38,6 +46,8 @@ public:
     ~PolyBook();
 
     void init(const std::string& bookfile);
+    void release();
+
     void set_best_book_move(bool best_book_move);
     void set_book_depth(int book_depth);
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -104,7 +104,11 @@ void init(OptionsMap& o) {
   o["Live Book Diversity"]   << Option(false);
   o["Live Book Contribute"]  << Option(false);
   o["Live Book Depth"]       << Option(100, 1, 100, on_livebook_depth);
+#if defined(POLY_EMBEDDING_ON)
+  o["BookFile"]              << Option("<internal>", on_book_file);
+#else
   o["BookFile"]              << Option("<empty>", on_book_file);
+#endif
   o["BookFile2"]             << Option("<empty>", on_book_file2);
   o["BestBookMove"]          << Option(true, on_best_book_move);
   o["BookDepth"]             << Option(255, 1, 255, on_book_depth);


### PR DESCRIPTION
This patch allows the engine to include embedded PolyGlot BIN book in the engine exe.

The feature is disabled by default. To enable, pass **CPPFLAGS=-DPOLY_EMBEDDING_ON** in the make command

Example: make.exe profile-build CPPFLAGS=-DPOLY_EMBEDDING_ON ARCH=x86-64-bmi2 COMP=mingw -j 8